### PR TITLE
Add linting and coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pandas numpy yfinance requests pytest pytest-cov ruff pre-commit
+      - uses: pre-commit/action@v3.0.1
+      - name: Run tests
+        run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.1
+    hooks:
+      - id: ruff
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: bash -c 'PYTHONPATH=. pytest'
+        language: system
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+    "D",
+    "ANN",
+    "S101",
+    "I",
+    "T201",
+    "BLE",
+    "PTH",
+    "F401",
+    "B007",
+    "C901",
+    "DTZ002",
+    "DTZ005",
+    "E402",
+    "E501",
+    "ERA001",
+    "F841",
+    "FBT001",
+    "INP001",
+    "LOG",
+    "N802",
+    "N803",
+    "N806",
+    "N816",
+    "PD011",
+    "PD901",
+    "PERF401",
+    "PLR0912",
+    "PLR0915",
+    "PLR2004",
+    "RET504",
+    "S113",
+    "SIM102",
+    "TRY300",
+    "TRY401",
+    "W293",
+]
+
+[tool.pytest.ini_options]
+addopts = "--cov=./ --cov-report=term-missing:skip-covered --cov-fail-under=20"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+pandas
+numpy
+yfinance
+requests
+pytest
+pytest-cov
+ruff
+pre-commit

--- a/tests/test_ema_crossover.py
+++ b/tests/test_ema_crossover.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from ema_crossover import get_signal
+
+
+def test_get_signal_buy():
+    w = pd.DataFrame({"ema_fast": [2], "ema_slow": [1]})
+    d = pd.DataFrame({"Close": [10], "sma200": [9]})
+    assert get_signal(w, d) == "BUY"
+
+
+def test_get_signal_sell():
+    w = pd.DataFrame({"ema_fast": [1], "ema_slow": [2]})
+    d = pd.DataFrame({"Close": [8], "sma200": [9]})
+    assert get_signal(w, d) == "SELL"
+
+
+def test_get_signal_hold():
+    w = pd.DataFrame({"ema_fast": [1.5], "ema_slow": [1.5]})
+    d = pd.DataFrame({"Close": [8], "sma200": [9]})
+    assert get_signal(w, d) == "HOLD"

--- a/tests/test_ibs.py
+++ b/tests/test_ibs.py
@@ -1,0 +1,15 @@
+import sys
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+sys.modules.setdefault("matplotlib", MagicMock())
+sys.modules.setdefault("matplotlib.pyplot", MagicMock())
+
+from ibs import calculate_ibs
+
+
+def test_calculate_ibs():
+    df = pd.DataFrame({"Open": [0], "High": [2], "Low": [1], "Close": [1.5]})
+    ibs_series = calculate_ibs(df)
+    assert ibs_series.iloc[0] == 0.5

--- a/tests/test_vinted_checker.py
+++ b/tests/test_vinted_checker.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock, patch
+
+from vinted_checker import search_item
+
+
+@patch("vinted_checker.requests.get")
+def test_search_item_hit(mock_get):
+    resp = MagicMock()
+    resp.json.return_value = {"items": [1]}
+    resp.raise_for_status.return_value = None
+    mock_get.return_value = resp
+    assert search_item("shoes", 10.0)
+
+
+@patch("vinted_checker.requests.get")
+def test_search_item_miss(mock_get):
+    resp = MagicMock()
+    resp.json.return_value = {"items": []}
+    resp.raise_for_status.return_value = None
+    mock_get.return_value = resp
+    assert not search_item("shoes", 10.0)


### PR DESCRIPTION
## Summary
- configure Ruff for strict linting with many ignores
- enforce coverage via pytest and pre-commit
- add pre-commit configuration
- run tests in CI workflow
- add basic unit tests for existing modules

## Testing
- `pre-commit run --files .github/workflows/ci.yml .pre-commit-config.yaml pyproject.toml requirements.txt tests/test_vinted_checker.py tests/test_ema_crossover.py tests/test_ibs.py tests/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c082e1088323a1daa27db0fc9583